### PR TITLE
add_noise function for the scheduler and forcing Kind::Half

### DIFF
--- a/examples/stable-diffusion/main.rs
+++ b/examples/stable-diffusion/main.rs
@@ -147,7 +147,7 @@ fn main() -> anyhow::Result<()> {
 
     let bsize = 1;
     tch::manual_seed(seed);
-    let mut latents = Tensor::randn(&[bsize, 4, HEIGHT / 8, WIDTH / 8], (Kind::Float, unet_device));
+    let mut latents = Tensor::randn(&[bsize, 4, HEIGHT / 8, WIDTH / 8], (Kind::Half, unet_device));
 
     for (timestep_index, &timestep) in scheduler.timesteps().iter().enumerate() {
         println!("Timestep {timestep_index}/{n_steps}");

--- a/src/models/attention.rs
+++ b/src/models/attention.rs
@@ -115,7 +115,7 @@ impl CrossAttention {
             let xs = query
                 .i(start_idx..end_idx)
                 .matmul(&(key.i(start_idx..end_idx).transpose(-1, -2) * self.scale))
-                .softmax(-1, Kind::Float)
+                .softmax(-1, Kind::Half)
                 .matmul(&value.i(start_idx..end_idx));
 
             let idx = Tensor::arange_start(start_idx, end_idx, (Kind::Int64, query.device()));
@@ -128,7 +128,7 @@ impl CrossAttention {
     fn attention(&self, query: &Tensor, key: &Tensor, value: &Tensor) -> Tensor {
         let xs = query
             .matmul(&(key.transpose(-1, -2) * self.scale))
-            .softmax(-1, Kind::Float)
+            .softmax(-1, Kind::Half)
             .matmul(value);
         self.reshape_batch_dim_to_heads(&xs)
     }
@@ -334,7 +334,7 @@ impl Module for AttentionBlock {
         let scale = f64::powf((self.channels as f64) / (self.num_heads as f64), -0.25);
         let attention_scores =
             (query_states * scale).matmul(&(key_states.transpose(-1, -2) * scale));
-        let attention_probs = attention_scores.softmax(-1, Kind::Float);
+        let attention_probs = attention_scores.softmax(-1, Kind::Half);
 
         let xs = attention_probs.matmul(&value_states);
         let xs = xs.permute(&[0, 2, 1, 3]).contiguous();

--- a/src/models/embeddings.rs
+++ b/src/models/embeddings.rs
@@ -44,7 +44,7 @@ impl Timesteps {
 impl Module for Timesteps {
     fn forward(&self, xs: &Tensor) -> Tensor {
         let half_dim = self.num_channels / 2;
-        let exponent = Tensor::arange(half_dim, (Kind::Float, self.device)) * -f64::ln(10000.);
+        let exponent = Tensor::arange(half_dim, (Kind::Half, self.device)) * -f64::ln(10000.);
         let exponent = exponent / (half_dim as f64 - self.downscale_freq_shift);
         let emb = exponent.exp();
         // emb = timesteps[:, None].float() * emb[None, :]

--- a/src/models/unet_2d.rs
+++ b/src/models/unet_2d.rs
@@ -230,7 +230,7 @@ impl UNet2DConditionModel {
         // 0. center input if necessary
         let xs = if self.config.center_input_sample { xs * 2.0 - 1.0 } else { xs.shallow_clone() };
         // 1. time
-        let emb = (Tensor::ones(&[bsize], (Kind::Float, device)) * timestep)
+        let emb = (Tensor::ones(&[bsize], (Kind::Half, device)) * timestep)
             .apply(&self.time_proj)
             .apply(&self.time_embedding);
         // 2. pre-process

--- a/src/pipelines/stable_diffusion.rs
+++ b/src/pipelines/stable_diffusion.rs
@@ -11,6 +11,7 @@ pub fn build_clip_transformer(
     let mut vs = nn::VarStore::new(device);
     let text_model = clip::ClipTextTransformer::new(vs.root());
     vs.load(clip_weights)?;
+    vs.half();
     Ok(text_model)
 }
 
@@ -25,6 +26,7 @@ pub fn build_vae(vae_weights: &str, device: Device) -> anyhow::Result<vae::AutoE
     };
     let autoencoder = vae::AutoEncoderKL::new(vs_ae.root(), 3, 3, autoencoder_cfg);
     vs_ae.load(vae_weights)?;
+    vs_ae.half();
     Ok(autoencoder)
 }
 
@@ -56,5 +58,6 @@ pub fn build_unet(
     };
     let unet = unet_2d::UNet2DConditionModel::new(vs_unet.root(), 4, 4, unet_cfg);
     vs_unet.load(unet_weights)?;
+    vs_unet.half();
     Ok(unet)
 }

--- a/src/transformers/clip.rs
+++ b/src/transformers/clip.rs
@@ -500,7 +500,7 @@ impl ClipAttention {
         let attn_weights =
             attn_weights.view((bsz, NUM_ATTENTION_HEADS, tgt_len, src_len)) + causal_attention_mask;
         let attn_weights = attn_weights.view((bsz * NUM_ATTENTION_HEADS, tgt_len, src_len));
-        let attn_weights = attn_weights.softmax(-1, Kind::Float);
+        let attn_weights = attn_weights.softmax(-1, Kind::Half);
 
         let attn_output = attn_weights.bmm(&value_states);
         attn_output
@@ -608,7 +608,7 @@ impl ClipTextTransformer {
     // https://github.com/huggingface/transformers/blob/674f750a57431222fa2832503a108df3badf1564/src/transformers/models/clip/modeling_clip.py#L678
     fn build_causal_attention_mask(bsz: i64, seq_len: i64, device: Device) -> Tensor {
         let mut mask = Tensor::ones(&[bsz, seq_len, seq_len], (Kind::Float, device));
-        mask.fill_(f32::MIN as f64).triu_(1).unsqueeze(1)
+        mask.fill_(f32::MIN as f64).triu_(1).unsqueeze(1).to_kind(Kind::Half)
     }
 }
 


### PR DESCRIPTION
This is just a draft PR to include the changes needed to run https://github.com/siriux/stable-diffusion-rs

One part is forcing Kind::Half in all needed places to be able to run with fp16 weights getting ~2x speedup.

The other is adding an add_noise function needed for the implementation of img2img at https://github.com/siriux/stable-diffusion-rs

This PR is not intended to merge, first a configurable way to handle the kind is needed.