### PR TITLE
Filter out unknown tokens instead of crashing

### DIFF
--- a/src/transformers/clip.rs
+++ b/src/transformers/clip.rs
@@ -449,7 +449,11 @@ impl Tokenizer {
             }
             word = new_word
         }
-        word.iter().map(|x| *self.encoder.get(x).unwrap()).collect()
+        word.iter()
+            .map(|x| self.encoder.get(x))
+            .flatten()
+            .map(|x| *x)
+            .collect()
     }
 
     pub fn encode_pad(&self, s: &str, pad_size_to: Option<usize>) -> anyhow::Result<Vec<usize>> {


### PR DESCRIPTION
Currently, when a word is not found, for example `didn’t` (notice the ’ instead of '), it just panics, since the unwrap is called on a None value.

Maybe you would prefer throwing an error instead, since this hides the oddity from the user.