### PR TITLE
Implement Euler Discrete Scheduler

### DIFF
--- a/src/schedulers/euler_discrete.rs
+++ b/src/schedulers/euler_discrete.rs
@@ -1,0 +1,146 @@
+use super::{interp, BetaSchedule, PredictionType};
+use tch::{kind, Kind, Tensor};
+
+#[derive(Debug, Clone)]
+pub struct EulerDiscreteSchedulerConfig {
+    /// The value of beta at the beginning of training.
+    pub beta_start: f64,
+    /// The value of beta at the end of training.
+    pub beta_end: f64,
+    /// How beta evolved during training.
+    pub beta_schedule: BetaSchedule,
+    /// number of diffusion steps used to train the model.
+    pub train_timesteps: usize,
+    /// prediction type of the scheduler function
+    pub prediction_type: PredictionType,
+}
+
+impl Default for EulerDiscreteSchedulerConfig {
+    fn default() -> Self {
+        Self {
+            beta_start: 0.0001,
+            beta_end: 0.02,
+            beta_schedule: BetaSchedule::Linear,
+            train_timesteps: 1000,
+            prediction_type: PredictionType::Epsilon,
+        }
+    }
+}
+
+/// Euler scheduler (Algorithm 2) from Karras et al. (2022) https://arxiv.org/abs/2206.00364.
+/// Based on the original
+/// k-diffusion implementation by Katherine Crowson:
+/// https://github.com/crowsonkb/k-diffusion/blob/481677d114f6ea445aa009cf5bd7a9cdee909e47/k_diffusion/sampling.py#L51
+#[derive(Clone)]
+pub struct EulerDiscreteScheduler {
+    timesteps: Vec<f64>,
+    sigmas: Vec<f64>,
+    init_noise_sigma: f64,
+    pub config: EulerDiscreteSchedulerConfig,
+}
+
+impl EulerDiscreteScheduler {
+    pub fn new(inference_steps: usize, config: EulerDiscreteSchedulerConfig) -> Self {
+        let betas = match config.beta_schedule {
+            BetaSchedule::ScaledLinear => Tensor::linspace(
+                config.beta_start.sqrt(),
+                config.beta_end.sqrt(),
+                config.train_timesteps as i64,
+                kind::FLOAT_CPU,
+            )
+            .square(),
+            BetaSchedule::Linear => Tensor::linspace(
+                config.beta_start,
+                config.beta_end,
+                config.train_timesteps as i64,
+                kind::FLOAT_CPU,
+            ),
+            _ => unimplemented!(
+                "EulerDiscreteScheduler only implements linear and scaled_linear betas."
+            ),
+        };
+
+        let alphas: Tensor = 1. - betas;
+        let alphas_cumprod = alphas.cumprod(0, Kind::Double);
+
+        // https://github.com/huggingface/diffusers/blob/2bd53a940c60d13421d9e8887af96b30a53c1b95/src/diffusers/schedulers/scheduling_euler_discrete.py#L149
+        let step = (config.train_timesteps - 1) as f64 / (inference_steps - 1) as f64;
+        let timesteps: Vec<f64> = (0..inference_steps).map(|i| i as f64 * step).rev().collect();
+
+        let sigmas = ((1. - &alphas_cumprod) as Tensor / &alphas_cumprod).sqrt();
+        let sigmas = interp(
+            &timesteps, // x-coordinates at which to evaluate the interpolated values
+            Tensor::range(0, sigmas.size1().unwrap() - 1, kind::FLOAT_CPU),
+            sigmas,
+        );
+
+        let mut sigmas = Vec::<f64>::from(sigmas);
+        sigmas.push(0.0);
+
+        // extracts max of sigmas, i.e. sigmas.max()
+        let init_noise_sigma = *sigmas.iter().max_by(|a, b| a.total_cmp(b)).unwrap();
+        Self { timesteps, sigmas, init_noise_sigma, config }
+    }
+
+    pub fn timesteps(&self) -> &[f64] {
+        self.timesteps.as_slice()
+    }
+
+    pub fn scale_model_input(&self, sample: Tensor, timestep: f64) -> Tensor {
+        let step_index = self.timesteps.iter().position(|&t| t == timestep).unwrap();
+        let sigma = self.sigmas[step_index];
+
+        // https://github.com/huggingface/diffusers/blob/2bd53a940c60d13421d9e8887af96b30a53c1b95/src/diffusers/schedulers/scheduling_euler_discrete.py#L133
+        sample / (sigma.powi(2) + 1.).sqrt()
+    }
+
+    pub fn step(&self, model_output: &Tensor, timestep: f64, sample: &Tensor) -> Tensor {
+        let (s_churn, s_tmin, s_tmax, s_noise) = (0.0, 0.0, f64::INFINITY, 1.0);
+
+        let step_index = self.timesteps.iter().position(|&t| t == timestep).unwrap();
+        let sigma = self.sigmas[step_index];
+
+        let gamma = if s_tmin <= sigma && sigma <= s_tmax {
+            (s_churn / (self.sigmas.len() as f64 - 1.)).min(2.0_f64.sqrt() - 1.)
+        } else {
+            0.0
+        };
+
+        let noise = Tensor::randn_like(model_output);
+        let eps = noise * s_noise;
+        let sigma_hat = sigma * (gamma + 1.);
+
+        let sample = if gamma > 0.0 {
+            sample + eps * (sigma_hat.powi(2) - sigma.powi(2)).sqrt()
+        } else {
+            sample.shallow_clone()
+        };
+
+        // 1. compute predicted original sample (x_0) from sigma-scaled predicted noise
+        let pred_original_sample = match self.config.prediction_type {
+            PredictionType::Epsilon => &sample - sigma_hat * model_output,
+            PredictionType::VPrediction => {
+                model_output * (-sigma / (sigma.powi(2) + 1.).sqrt())
+                    + (&sample / (sigma.powi(2) + 1.))
+            }
+            _ => unimplemented!("Prediction type must be one of `epsilon` or `v_prediction`"),
+        };
+
+        // 2. Convert to an ODE derivative
+        let derivative = (&sample - pred_original_sample) / sigma_hat;
+        let dt = self.sigmas[step_index + 1] - sigma_hat;
+
+        sample + derivative * dt
+    }
+
+    pub fn init_noise_sigma(&self) -> f64 {
+        self.init_noise_sigma
+    }
+
+    pub fn add_noise(&self, original_samples: &Tensor, noise: Tensor, timestep: f64) -> Tensor {
+        let step_index = self.timesteps.iter().position(|&t| t == timestep).unwrap();
+        let sigma = self.sigmas[step_index];
+
+        original_samples + noise * sigma
+    }
+}


### PR DESCRIPTION
Hi @LaurentMazare,
this PR aims at integrating the [Euler Discrete Scheduler](https://github.com/huggingface/diffusers/blob/main/src/diffusers/schedulers/scheduling_euler_discrete.py) into this repository, solving the first task mentioned in #23.

The implementation should contain all the features of the python version. Please notice that, differently from the other schedulers currently supported, here `init_noise_sigma` is not equal to 1.0. Also, this scheduler requires to scale the denoising model input. We might say that the other 3 schedulers supported by diffusers-rs are a "special" case. 

Therefore, to run the stable diffusion pipeline with this scheduler, one needs to multiply the initial latents by `init_noise_sigma` [here](https://github.com/LaurentMazare/diffusers-rs/blob/main/examples/stable-diffusion/main.rs#L271-L274)  ([Python version](https://github.com/huggingface/diffusers/blob/da31075700eb5f7aae1eb974a1c185e53b74f316/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L418))

```rust
let mut latents = Tensor::randn(
    &[bsize, 4, sd_config.height / 8, sd_config.width / 8],
    (Kind::Float, unet_device),
) * scheduler.init_noise_sigma();
```

and to scale the model input after [this line](https://github.com/LaurentMazare/diffusers-rs/blob/main/examples/stable-diffusion/main.rs#L278) ([Python version](https://github.com/huggingface/diffusers/blob/da31075700eb5f7aae1eb974a1c185e53b74f316/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L542))

```rust
let latent_model_input = scheduler.scale_model_input(latent_model_input, timestep);
```

HF's python version makes everything consistent implementing `init_noise_sigma()` and `scale_model_input()` in all the schedulers.  If you wish,  I can fix the example in this PR (and, thereby, add a `scale_model_input` method to all the schedulers, which only returns `sample` when no scaling is needed, i.e. what HF does). Otherwise, I can open a new one. 

Overall, I believe this PR is self-contained regardless of the pipeline examples.


EDIT: the above text is a little dense.
To sum up:
* This PR implements Euler discrete, porting all the features from HF diffusers.
* the stable diffusion pipeline examples require  to be updated, as they assume that `init_noise_sigma` is 1.0 and that the denoising model input doesn't need to be scaled. I propose to copy what HF does, i.e. making all the schedulers implement a getter for `init_noise_sigma` (done already for all the schedulers I implemented in the past 2 weeks) and a `scale_model_input` method which simply returns `sample` when no scaling is needed :)

  ```rust
  pub fn scale_model_input(&self, sample: Tensor, timestep: f64) -> Tensor {
       sample 
  }
  ```
  However, this is, in my opinion, outside of the scope of this PR as it only aims at adding a new scheduler.

EDIT 2: I did what I mentioned in the second bullet in this [branch](https://github.com/mspronesti/diffusers-rs/tree/hf-scheduler-interface). If you agree, I will open a new PR once this gets merged (assuming you find these valuable contributions to diffusers-rs :)  ) 