### PR TITLE
Optimize scheduler defaults

### DIFF
--- a/src/schedulers/ddpm.rs
+++ b/src/schedulers/ddpm.rs
@@ -37,9 +37,9 @@ pub struct DDPMSchedulerConfig {
 impl Default for DDPMSchedulerConfig {
     fn default() -> Self {
         Self {
-            beta_start: 0.0001,
-            beta_end: 0.02,
-            beta_schedule: BetaSchedule::Linear,
+            beta_start: 0.00085,
+            beta_end: 0.012,
+            beta_schedule: BetaSchedule::ScaledLinear,
             clip_sample: true,
             variance_type: DDPMVarianceType::FixedSmall,
             prediction_type: PredictionType::Epsilon,

--- a/src/schedulers/dpmsolver_multistep.rs
+++ b/src/schedulers/dpmsolver_multistep.rs
@@ -1,4 +1,5 @@
 use super::{betas_for_alpha_bar, BetaSchedule, PredictionType};
+use std::iter;
 use tch::{kind, Kind, Tensor};
 
 /// The algorithm type for the solver.
@@ -112,16 +113,15 @@ impl DPMSolverMultistepScheduler {
             .rev()
             .collect();
 
-        let mut model_outputs = Vec::<Tensor>::new();
-        for _ in 0..config.solver_order {
-            model_outputs.push(Tensor::new());
-        }
+        // creates a vector of `solver_order` empty tensors
+        // https://github.com/huggingface/diffusers/blob/e4fe9413121b78c4c1f109b50f0f3cc1c320a1a2/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py#L206-L208
+        let model_outputs = iter::repeat_with(Tensor::new).take(config.solver_order).collect();
 
         Self {
-            alphas_cumprod: Vec::<f64>::from(alphas_cumprod),
-            alpha_t: Vec::<f64>::from(alpha_t),
-            sigma_t: Vec::<f64>::from(sigma_t),
-            lambda_t: Vec::<f64>::from(lambda_t),
+            alphas_cumprod: alphas_cumprod.into(),
+            alpha_t: alpha_t.into(),
+            sigma_t: sigma_t.into(),
+            lambda_t: lambda_t.into(),
             init_noise_sigma: 1.,
             lower_order_nums: 0,
             model_outputs,

--- a/src/schedulers/dpmsolver_multistep.rs
+++ b/src/schedulers/dpmsolver_multistep.rs
@@ -53,9 +53,9 @@ pub struct DPMSolverMultistepSchedulerConfig {
 impl Default for DPMSolverMultistepSchedulerConfig {
     fn default() -> Self {
         Self {
-            beta_start: 0.0001,
-            beta_end: 0.02,
-            beta_schedule: BetaSchedule::Linear,
+            beta_start: 0.00085,
+            beta_end: 0.012,
+            beta_schedule: BetaSchedule::ScaledLinear,
             train_timesteps: 1000,
             solver_order: 2,
             prediction_type: PredictionType::Epsilon,

--- a/src/schedulers/euler_ancestral_discrete.rs
+++ b/src/schedulers/euler_ancestral_discrete.rs
@@ -18,9 +18,9 @@ pub struct EulerAncestralDiscreteSchedulerConfig {
 impl Default for EulerAncestralDiscreteSchedulerConfig {
     fn default() -> Self {
         Self {
-            beta_start: 0.0001,
-            beta_end: 0.02,
-            beta_schedule: BetaSchedule::Linear,
+            beta_start: 0.00085,
+            beta_end: 0.012,
+            beta_schedule: BetaSchedule::ScaledLinear,
             train_timesteps: 1000,
             prediction_type: PredictionType::Epsilon,
         }

--- a/src/schedulers/euler_discrete.rs
+++ b/src/schedulers/euler_discrete.rs
@@ -18,9 +18,9 @@ pub struct EulerDiscreteSchedulerConfig {
 impl Default for EulerDiscreteSchedulerConfig {
     fn default() -> Self {
         Self {
-            beta_start: 0.0001,
-            beta_end: 0.02,
-            beta_schedule: BetaSchedule::Linear,
+            beta_start: 0.00085,
+            beta_end: 0.012,
+            beta_schedule: BetaSchedule::ScaledLinear,
             train_timesteps: 1000,
             prediction_type: PredictionType::Epsilon,
         }


### PR DESCRIPTION
This PR aims at optimizing the scheduler defaults for stable diffusion pipelines.

Today I noticed by accident that the defaults values for `beta_start`, `beta_end` and `beta_schedule` that HF uses in all the schedulers that I implemented in the past 3 weeks are not optimal for stable diffusion. This is why some of the images generated were "not so good". For instance, as somebody was pointing out in my last PR, Euler Ancestral Discrete was not producing very good looking images (coherently with the results yielded by the Python version from huggingface). Here's  a comparison of the "correct" defaults vs the current ones, using 21 inference steps and 1573789502 as seed

![image](https://user-images.githubusercontent.com/44113430/212400316-2c538e81-7588-41be-9a8c-057530a5e339.png)
![image](https://user-images.githubusercontent.com/44113430/212400367-26cf3ad0-a02a-4f27-9184-fa1e4abe2cdd.png)

Here's the same comparison for Euler Discrete using the same seed and 15 inference steps.

![sd_final](https://user-images.githubusercontent.com/44113430/212354000-6772df50-c2ac-49d4-85bb-652c8d35533b.png). 

![sd_final](https://user-images.githubusercontent.com/44113430/212355223-adc07195-7b6c-4328-b21c-e83cded09dfa.png)

Other produced images using Euler Ancestral Discrete:

![image](https://user-images.githubusercontent.com/44113430/212418856-b3772db7-9089-4484-b942-ee136c774ae8.png)
![image](https://user-images.githubusercontent.com/44113430/212421252-415fca3b-d459-47d0-a955-76453583c254.png)


The same applies to DDPM and DPM Multistep. DDIM and Heun Discrete already had these hyperparameters "appropriately" defaulted.

Lastly, I did some minor tweaks in a separate commit, just in case you prefer to keep the commit history cleaner merging them without squashing (assuming you find these contributions valuable :) )