### PR TITLE
Simplify tensor operations and interpolation

### DIFF
--- a/src/schedulers/euler_ancestral_discrete.rs
+++ b/src/schedulers/euler_ancestral_discrete.rs
@@ -56,16 +56,19 @@ impl EulerAncestralDiscreteScheduler {
                 kind::FLOAT_CPU,
             ),
             _ => unimplemented!(
-                "EulerDiscreteScheduler only implements linear and scaled_linear betas."
+                "EulerAncestralDiscreteScheduler only implements linear and scaled_linear betas."
             ),
         };
 
         let alphas: Tensor = 1. - betas;
         let alphas_cumprod = alphas.cumprod(0, Kind::Double);
 
-        // https://github.com/huggingface/diffusers/blob/2bd53a940c60d13421d9e8887af96b30a53c1b95/src/diffusers/schedulers/scheduling_euler_discrete.py#L149
-        let step = (config.train_timesteps - 1) as f64 / (inference_steps - 1) as f64;
-        let timesteps: Vec<f64> = (0..inference_steps).map(|i| i as f64 * step).rev().collect();
+        let timesteps = Tensor::linspace(
+            (config.train_timesteps - 1) as f64,
+            0.,
+            inference_steps as i64,
+            kind::FLOAT_CPU,
+        );
 
         let sigmas = ((1. - &alphas_cumprod) as Tensor / &alphas_cumprod).sqrt();
         let sigmas = interp(
@@ -74,12 +77,11 @@ impl EulerAncestralDiscreteScheduler {
             sigmas,
         );
 
-        let mut sigmas = Vec::<f64>::from(sigmas);
-        sigmas.push(0.0);
+        let sigmas = Tensor::concat(&[sigmas, Tensor::of_slice(&[0.0])], 0);
 
-        // extracts max of sigmas, i.e. sigmas.max()
-        let init_noise_sigma = *sigmas.iter().max_by(|a, b| a.total_cmp(b)).unwrap();
-        Self { timesteps, sigmas, init_noise_sigma, config }
+        // standard deviation of the initial noise distribution
+        let init_noise_sigma: f64 = sigmas.max().into();
+        Self { timesteps: timesteps.into(), sigmas: sigmas.into(), init_noise_sigma, config }
     }
 
     pub fn timesteps(&self) -> &[f64] {

--- a/src/schedulers/lms_discrete.rs
+++ b/src/schedulers/lms_discrete.rs
@@ -64,9 +64,12 @@ impl LMSDiscreteScheduler {
         let alphas: Tensor = 1. - betas;
         let alphas_cumprod = alphas.cumprod(0, Kind::Double);
 
-        // https://github.com/huggingface/diffusers/blob/769f0be8fb41daca9f3cbcffcfd0dbf01cc194b8/src/diffusers/schedulers/scheduling_lms_discrete.py#L170
-        let step = (config.train_timesteps - 1) as f64 / (inference_steps - 1) as f64;
-        let timesteps: Vec<f64> = (0..inference_steps).map(|i| i as f64 * step).rev().collect();
+        let timesteps = Tensor::linspace(
+            (config.train_timesteps - 1) as f64,
+            0.,
+            inference_steps as i64,
+            kind::FLOAT_CPU,
+        );
 
         let sigmas = ((1. - &alphas_cumprod) as Tensor / &alphas_cumprod).sqrt();
         let sigmas = interp(
@@ -79,7 +82,13 @@ impl LMSDiscreteScheduler {
         // standard deviation of the initial noise distribution
         let init_noise_sigma: f64 = sigmas.max().into();
 
-        Self { timesteps, sigmas: sigmas.into(), init_noise_sigma, derivatives: vec![], config }
+        Self {
+            timesteps: timesteps.into(),
+            sigmas: sigmas.into(),
+            init_noise_sigma,
+            derivatives: vec![],
+            config,
+        }
     }
 
     pub fn timesteps(&self) -> &[f64] {


### PR DESCRIPTION
Hi,
this PR aims at simplifying some of the operations done in the setup of some of the schedulers I implemented in the past weeks, relying more on the `tch` crate and reducing the number of casts to vectors.

Specifically: 
* simplify tensor interpolation: previously, since I didn't know `tch` supported a pytorch-equivalent of `ge`, called `ge_tensor` - `ge` in `tch` only accepts a scalar -  I used a vector of tensors whose elements were eventually stacked. Now, I only work with tensors, thus porting exactly the python version.
* reduce number of casts from Tensors to Vecs, mainly relying more on `cat` and `linspace` instead of working with ranges and `Vec::push`
* stylistic change: wherever possible, I replaced `slice` with `.i(<range>)` to improve readability 