### PR TITLE
Add height and width flags

### DIFF
--- a/examples/stable-diffusion-img2img/main.rs
+++ b/examples/stable-diffusion-img2img/main.rs
@@ -154,10 +154,10 @@ fn run(args: Args) -> anyhow::Result<()> {
     println!("Cudnn available: {}", tch::Cuda::cudnn_is_available());
     let sd_config = match sd_version {
         StableDiffusionVersion::V1_5 => {
-            stable_diffusion::StableDiffusionConfig::v1_5(sliced_attention_size)
+            stable_diffusion::StableDiffusionConfig::v1_5(sliced_attention_size, None, None)
         }
         StableDiffusionVersion::V2_1 => {
-            stable_diffusion::StableDiffusionConfig::v2_1(sliced_attention_size)
+            stable_diffusion::StableDiffusionConfig::v2_1(sliced_attention_size, None, None)
         }
     };
 

--- a/examples/stable-diffusion-inpaint/main.rs
+++ b/examples/stable-diffusion-inpaint/main.rs
@@ -42,6 +42,14 @@ struct Args {
     #[arg(long)]
     cpu: Vec<String>,
 
+    /// The height in pixels of the generated image.
+    #[arg(long)]
+    height: Option<i64>,
+
+    /// The width in pixels of the generated image.
+    #[arg(long)]
+    width: Option<i64>,
+
     #[arg(long, value_name = "FILE", default_value = "data/bpe_simple_vocab_16e6.txt")]
     /// The file specifying the vocabulary to used for tokenization.
     vocab_file: String,
@@ -141,6 +149,8 @@ fn run(args: Args) -> anyhow::Result<()> {
     let Args {
         prompt,
         cpu,
+        height,
+        width,
         n_steps,
         seed,
         final_image,
@@ -157,10 +167,10 @@ fn run(args: Args) -> anyhow::Result<()> {
     println!("Cudnn available: {}", tch::Cuda::cudnn_is_available());
     let sd_config = match sd_version {
         StableDiffusionVersion::V1_5 => {
-            stable_diffusion::StableDiffusionConfig::v1_5(sliced_attention_size)
+            stable_diffusion::StableDiffusionConfig::v1_5(sliced_attention_size, height, width)
         }
         StableDiffusionVersion::V2_1 => {
-            stable_diffusion::StableDiffusionConfig::v2_1(sliced_attention_size)
+            stable_diffusion::StableDiffusionConfig::v2_1(sliced_attention_size, height, width)
         }
     };
     let (mask, masked_image) = prepare_mask_and_masked_image(input_image, mask_image)?;

--- a/examples/stable-diffusion/main.rs
+++ b/examples/stable-diffusion/main.rs
@@ -90,6 +90,14 @@ struct Args {
     #[arg(long)]
     cpu: Vec<String>,
 
+    /// The height in pixels of the generated image.
+    #[arg(long)]
+    height: Option<i64>,
+
+    /// The width in pixels of the generated image.
+    #[arg(long)]
+    width: Option<i64>,
+
     /// The UNet weight file, in .ot format.
     #[arg(long, value_name = "FILE")]
     unet_weights: Option<String>,
@@ -210,6 +218,8 @@ fn run(args: Args) -> anyhow::Result<()> {
     let Args {
         prompt,
         cpu,
+        height,
+        width,
         n_steps,
         seed,
         vocab_file,
@@ -226,12 +236,13 @@ fn run(args: Args) -> anyhow::Result<()> {
 
     let sd_config = match sd_version {
         StableDiffusionVersion::V1_5 => {
-            stable_diffusion::StableDiffusionConfig::v1_5(sliced_attention_size)
+            stable_diffusion::StableDiffusionConfig::v1_5(sliced_attention_size, height, width)
         }
         StableDiffusionVersion::V2_1 => {
-            stable_diffusion::StableDiffusionConfig::v2_1(sliced_attention_size)
+            stable_diffusion::StableDiffusionConfig::v2_1(sliced_attention_size, height, width)
         }
     };
+
     let device_setup = diffusers::utils::DeviceSetup::new(cpu);
     let clip_device = device_setup.get("clip");
     let vae_device = device_setup.get("vae");

--- a/src/pipelines/stable_diffusion.rs
+++ b/src/pipelines/stable_diffusion.rs
@@ -15,7 +15,11 @@ pub struct StableDiffusionConfig {
 }
 
 impl StableDiffusionConfig {
-    pub fn v1_5(sliced_attention_size: Option<i64>) -> Self {
+    pub fn v1_5(
+        sliced_attention_size: Option<i64>,
+        height: Option<i64>,
+        width: Option<i64>,
+    ) -> Self {
         let bc = |out_channels, use_cross_attn, attention_head_dim| unet_2d::BlockConfig {
             out_channels,
             use_cross_attn,
@@ -42,9 +46,23 @@ impl StableDiffusionConfig {
             latent_channels: 4,
             norm_num_groups: 32,
         };
+        let height = if let Some(height) = height {
+            assert_eq!(height % 8, 0, "heigh has to be divisible by 8");
+            height
+        } else {
+            512
+        };
+
+        let width = if let Some(width) = width {
+            assert_eq!(width % 8, 0, "width has to be divisible by 8");
+            width
+        } else {
+            512
+        };
+
         Self {
-            width: 512,
-            height: 512,
+            width,
+            height,
             clip: clip::Config::v1_5(),
             autoencoder,
             scheduler: Default::default(),
@@ -52,7 +70,11 @@ impl StableDiffusionConfig {
         }
     }
 
-    pub fn v2_1(sliced_attention_size: Option<i64>) -> Self {
+    pub fn v2_1(
+        sliced_attention_size: Option<i64>,
+        height: Option<i64>,
+        width: Option<i64>,
+    ) -> Self {
         let bc = |out_channels, use_cross_attn, attention_head_dim| unet_2d::BlockConfig {
             out_channels,
             use_cross_attn,
@@ -89,7 +111,22 @@ impl StableDiffusionConfig {
             prediction_type: PredictionType::VPrediction,
             ..Default::default()
         };
-        Self { width: 768, height: 768, clip: clip::Config::v2_1(), autoencoder, scheduler, unet }
+
+        let height = if let Some(height) = height {
+            assert_eq!(height % 8, 0, "heigh has to be divisible by 8");
+            height
+        } else {
+            768
+        };
+
+        let width = if let Some(width) = width {
+            assert_eq!(width % 8, 0, "width has to be divisible by 8");
+            width
+        } else {
+            768
+        };
+
+        Self { width, height, clip: clip::Config::v2_1(), autoencoder, scheduler, unet }
     }
 
     pub fn build_vae(


### PR DESCRIPTION
This PR aims at supporting height and width flags, solving #31 . I tried to keep your design of the pipelines unchanged: if not specified, the SD pipelines uses the default values previously assigned depending on the chosen version of stable diffusion (512x512 for v1.5, 768x768 for v2.1).
