### PR TITLE
Support load from safe tensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 .*~
 sd_*jpg
 sd_*png
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1"
 thiserror = "1"
 regex = "1.6.0"
 tch = "0.10.3"
+safetensors = "0.2.8"
 
 clap = { version = "4.0.19", optional = true, features = ["derive"] }
 


### PR DESCRIPTION
Solve #53 

It can also work with official safetensors without convert weights now!

https://huggingface.co/runwayml/stable-diffusion-v1-5/blob/main/unet/diffusion_pytorch_model.safetensors

```sh
cargo run --example stable-diffusion --features clap -- --prompt "A rusty robot holding a fire torch." --sd-version=v1-5 --intermediary-images --unet-weights="data/diffusion_pytorch_model.safetensors"
```

Wrap function can be removed when https://github.com/LaurentMazare/tch-rs/pull/633 merged.

