### PR TITLE
fix(schedulers): bug when predict_type is sample

### DIFF
--- a/examples/stable-diffusion-img2img/main.rs
+++ b/examples/stable-diffusion-img2img/main.rs
@@ -200,7 +200,8 @@ fn run(args: Args) -> anyhow::Result<()> {
         tch::manual_seed(seed + idx);
         let latents = (init_latent_dist.sample() * 0.18215).to(unet_device);
         let timesteps = scheduler.timesteps();
-        let mut latents = scheduler.add_noise(&latents, timesteps[t_start]);
+        let noise = latents.randn_like();
+        let mut latents = scheduler.add_noise(&latents, noise, timesteps[t_start]);
 
         for (timestep_index, &timestep) in timesteps.iter().enumerate() {
             if timestep_index < t_start {


### PR DESCRIPTION
Hi, 
this PR aims at solving solving a minor bug in DDIM scheduler when prediction type is `Sample` (as in [2094](https://github.com/huggingface/diffusers/pull/2094)) and to align `add_noise` prototype to all other schedulers (and to HF diffusers).
