### PR TITLE
Switch to using safetensors by default instead of ot.

### DIFF
--- a/examples/stable-diffusion-img2img/main.rs
+++ b/examples/stable-diffusion-img2img/main.rs
@@ -31,15 +31,15 @@ struct Args {
     #[arg(long)]
     cpu: Vec<String>,
 
-    /// The UNet weight file, in .ot format.
+    /// The UNet weight file, in .ot or .safetensors format.
     #[arg(long, value_name = "FILE")]
     unet_weights: Option<String>,
 
-    /// The CLIP weight file, in .ot format.
+    /// The CLIP weight file, in .ot or .safetensors format.
     #[arg(long, value_name = "FILE")]
     clip_weights: Option<String>,
 
-    /// The VAE weight file, in .ot format.
+    /// The VAE weight file, in .ot or .safetensors format.
     #[arg(long, value_name = "FILE")]
     vae_weights: Option<String>,
 
@@ -92,8 +92,8 @@ impl Args {
         match &self.clip_weights {
             Some(w) => w.clone(),
             None => match self.sd_version {
-                StableDiffusionVersion::V1_5 => "data/pytorch_model.ot".to_string(),
-                StableDiffusionVersion::V2_1 => "data/clip_v2.1.ot".to_string(),
+                StableDiffusionVersion::V1_5 => "data/pytorch_model.safetensors".to_string(),
+                StableDiffusionVersion::V2_1 => "data/clip_v2.1.safetensors".to_string(),
             },
         }
     }
@@ -102,8 +102,8 @@ impl Args {
         match &self.vae_weights {
             Some(w) => w.clone(),
             None => match self.sd_version {
-                StableDiffusionVersion::V1_5 => "data/vae.ot".to_string(),
-                StableDiffusionVersion::V2_1 => "data/vae_v2.1.ot".to_string(),
+                StableDiffusionVersion::V1_5 => "data/vae.safetensors".to_string(),
+                StableDiffusionVersion::V2_1 => "data/vae_v2.1.safetensors".to_string(),
             },
         }
     }
@@ -112,8 +112,8 @@ impl Args {
         match &self.unet_weights {
             Some(w) => w.clone(),
             None => match self.sd_version {
-                StableDiffusionVersion::V1_5 => "data/unet.ot".to_string(),
-                StableDiffusionVersion::V2_1 => "data/unet_v2.1.ot".to_string(),
+                StableDiffusionVersion::V1_5 => "data/unet.safetensors".to_string(),
+                StableDiffusionVersion::V2_1 => "data/unet_v2.1.safetensors".to_string(),
             },
         }
     }

--- a/examples/stable-diffusion-inpaint/main.rs
+++ b/examples/stable-diffusion-inpaint/main.rs
@@ -54,15 +54,15 @@ struct Args {
     /// The file specifying the vocabulary to used for tokenization.
     vocab_file: String,
 
-    /// The UNet weight file, in .ot format.
+    /// The UNet weight file, in .ot or .safetensors format.
     #[arg(long, value_name = "FILE")]
     unet_weights: Option<String>,
 
-    /// The CLIP weight file, in .ot format.
+    /// The CLIP weight file, in .ot or .safetensors format.
     #[arg(long, value_name = "FILE")]
     clip_weights: Option<String>,
 
-    /// The VAE weight file, in .ot format.
+    /// The VAE weight file, in .ot or .safetensors format.
     #[arg(long, value_name = "FILE")]
     vae_weights: Option<String>,
 
@@ -101,8 +101,8 @@ impl Args {
         match &self.clip_weights {
             Some(w) => w.clone(),
             None => match self.sd_version {
-                StableDiffusionVersion::V1_5 => "data/pytorch_model.ot".to_string(),
-                StableDiffusionVersion::V2_1 => "data/clip_v2.1.ot".to_string(),
+                StableDiffusionVersion::V1_5 => "data/pytorch_model.safetensors".to_string(),
+                StableDiffusionVersion::V2_1 => "data/clip_v2.1.safetensors".to_string(),
             },
         }
     }
@@ -111,8 +111,8 @@ impl Args {
         match &self.vae_weights {
             Some(w) => w.clone(),
             None => match self.sd_version {
-                StableDiffusionVersion::V1_5 => "data/vae.ot".to_string(),
-                StableDiffusionVersion::V2_1 => "data/vae_v2.1.ot".to_string(),
+                StableDiffusionVersion::V1_5 => "data/vae.safetensors".to_string(),
+                StableDiffusionVersion::V2_1 => "data/vae_v2.1.safetensors".to_string(),
             },
         }
     }
@@ -121,8 +121,8 @@ impl Args {
         match &self.unet_weights {
             Some(w) => w.clone(),
             None => match self.sd_version {
-                StableDiffusionVersion::V1_5 => "data/unet-inpaint.ot".to_string(),
-                StableDiffusionVersion::V2_1 => "data/unet-inpaint_v2.1.ot".to_string(),
+                StableDiffusionVersion::V1_5 => "data/unet-inpaint.safetensors".to_string(),
+                StableDiffusionVersion::V2_1 => "data/unet-inpaint_v2.1.safetensors".to_string(),
             },
         }
     }


### PR DESCRIPTION
The conversion to safetensors is slightly simpler as it can fully be done on the python side, and the file format is likely to be more stable over time, so switch to recommend using `.safetensors` instead of `.ot` and make it the default.